### PR TITLE
Format extensions

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
@@ -17,6 +17,10 @@ package nl.knaw.dans.lib.logging.servlet
 
 import org.scalatra.{ MultiParams, ScalatraBase }
 
+/**
+ * Base trait for extending the `RequestLogFormatter`. Every custom request formatter must extend
+ * this trait. For usage, see the documentation in the package object.
+ */
 trait RequestLogExtensionBase extends RequestLogFormatter {
   this: ScalatraBase =>
 

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
@@ -49,7 +49,7 @@ trait RequestLogExtensionBase extends RequestLogFormatter {
 
   /**
    * Formats (masking, prettyprinting, etc.) the given parameter's value for logging purposes.
-   * By default it leaves the parameter untouched, but other implementations may provide other
+   * By default it leaves the parameter unformatted, but other implementations may provide other
    * formattings.
    *
    * Note that this does not change the content of the specific parameter in the actual request.

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.logging.servlet
 
 import org.scalatra.{ MultiParams, ScalatraBase }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogExtensionBase.scala
@@ -1,0 +1,42 @@
+package nl.knaw.dans.lib.logging.servlet
+
+import org.scalatra.{ MultiParams, ScalatraBase }
+
+trait RequestLogExtensionBase extends RequestLogFormatter {
+  this: ScalatraBase =>
+
+  /**
+   * @inheritdoc
+   */
+  override protected def formatHeaders(headers: HeaderMap): HeaderMap = {
+    headers.map(formatHeader)
+  }
+
+  /**
+   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
+   * Note that this does not change the content of the specific header in the actual request.
+   *
+   * @param header the header to be formatted
+   * @return the formatted header
+   */
+  protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = header
+
+  /**
+   * @inheritdoc
+   */
+  override protected def formatParameters(params: MultiParams): MultiParams = {
+    params.map(formatParameter)
+  }
+
+  /**
+   * Formats (masking, prettyprinting, etc.) the given parameter's value for logging purposes.
+   * By default it leaves the parameter untouched, but other implementations may provide other
+   * formattings.
+   *
+   * Note that this does not change the content of the specific parameter in the actual request.
+   *
+   * @param param the parameter to be formatted
+   * @return the formatted parameter
+   */
+  protected def formatParameter(param: MultiParamsEntry): MultiParamsEntry = param
+}

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
@@ -43,7 +43,7 @@ trait RequestLogFormatter {
    * Maps over all headers in this request and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `HeaderMap` with the same keys and the formatted values.
    *
-   * By default it leaves the headers untouched, but other implementations may provide other
+   * By default it leaves the headers unformatted, but other implementations may provide other
    * formattings.
    *
    * Note that this does not change the formatting of the headers in the actual request.
@@ -64,7 +64,7 @@ trait RequestLogFormatter {
    * Maps over all parameters in this request and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `MultiParams` with the same keys and the formatted values.
    *
-   * By default it leaves the parameters untouched, but other implementations may provide other
+   * By default it leaves the parameters unformatted, but other implementations may provide other
    * formattings.
    *
    * Note that this does not change the content of the parameters in the actual request.
@@ -76,7 +76,7 @@ trait RequestLogFormatter {
 
   /**
    * Formats (masking, prettyprinting, etc.) the request's remote address for logging purposes.
-   * By default it leaves the address untouched, but other implementations may provide other
+   * By default it leaves the address unformatted, but other implementations may provide other
    * formattings.
    *
    * Note that this does not change the remote address in the actual request.

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
@@ -43,26 +43,15 @@ trait RequestLogFormatter {
    * Maps over all headers in this request and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `HeaderMap` with the same keys and the formatted values.
    *
+   * By default it leaves the headers untouched, but other implementations may provide other
+   * formattings.
+   *
    * Note that this does not change the formatting of the headers in the actual request.
    *
    * @param headers the headers to be formatted
    * @return a mapping of the headers' keys to their formatted values
    */
-  protected def formatHeaders(headers: HeaderMap): HeaderMap = {
-    headers.map(formatHeader)
-  }
-
-  /**
-   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
-   * By default it leaves the header untouched, but other implementations may provide other
-   * formattings.
-   *
-   * Note that this does not change the content of the specific header in the actual request.
-   *
-   * @param header the header to be formatted
-   * @return the formatted header
-   */
-  protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = header
+  protected def formatHeaders(headers: HeaderMap): HeaderMap = headers
 
   private def getHeaderMap(request: HttpServletRequest): HeaderMap = {
     // looks the same method as for ResponseLogFormatter, but everywhere different classes
@@ -75,26 +64,15 @@ trait RequestLogFormatter {
    * Maps over all parameters in this request and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `MultiParams` with the same keys and the formatted values.
    *
+   * By default it leaves the parameters untouched, but other implementations may provide other
+   * formattings.
+   *
    * Note that this does not change the content of the parameters in the actual request.
    *
    * @param params the parameters to be formatted
    * @return a mapping of the parameters' keys to their formatted values
    */
-  protected def formatParameters(params: MultiParams): MultiParams = {
-    params.map(formatParameter)
-  }
-
-  /**
-   * Formats (masking, prettyprinting, etc.) the given parameter's value for logging purposes.
-   * By default it leaves the parameter untouched, but other implementations may provide other
-   * formattings.
-   *
-   * Note that this does not change the content of the specific parameter in the actual request.
-   *
-   * @param param the parameter to be formatted
-   * @return the formatted parameter
-   */
-  protected def formatParameter(param: MultiParamsEntry): MultiParamsEntry = param
+  protected def formatParameters(params: MultiParams): MultiParams = params
 
   /**
    * Formats (masking, prettyprinting, etc.) the request's remote address for logging purposes.

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
@@ -17,6 +17,10 @@ package nl.knaw.dans.lib.logging.servlet
 
 import org.scalatra.ScalatraBase
 
+/**
+ * Base trait for extending the `ResponseLogFormatter`. Every custom response formatter must extend
+ * this trait. For usage, see the documentation in the package object.
+ */
 trait ResponseLogExtensionBase extends ResponseLogFormatter {
   this: ScalatraBase =>
 

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.logging.servlet
 
 import org.scalatra.ScalatraBase

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogExtensionBase.scala
@@ -1,0 +1,39 @@
+package nl.knaw.dans.lib.logging.servlet
+
+import org.scalatra.ScalatraBase
+
+trait ResponseLogExtensionBase extends ResponseLogFormatter {
+  this: ScalatraBase =>
+
+  /**
+   * @inheritdoc
+   */
+  override protected def formatResponseHeaders(headers: HeaderMap): HeaderMap = {
+    headers.map(formatResponseHeader)
+  }
+
+  /**
+   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
+   * Note that this does not change the content of the specific header in the actual response.
+   *
+   * @param header the header to be formatted
+   * @return the formatted header
+   */
+  protected def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = header
+
+  /**
+   * @inheritdoc
+   */
+  override protected def formatActionHeaders(actionHeaders: ActionHeadersMap): ActionHeadersMap = {
+    actionHeaders.map(formatActionHeader)
+  }
+
+  /**
+   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
+   * Note that this does not change the content of the specific header in the actual response.
+   *
+   * @param header the header to be formatted
+   * @return the formatted header
+   */
+  protected def formatActionHeader(header: ActionHeaderEntry): ActionHeaderEntry = header
+}

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
@@ -42,7 +42,7 @@ trait ResponseLogFormatter {
    * Maps over all headers in this response and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `HeaderMap` with the same keys and the formatted values.
    *
-   * By default it leaves the headers untouched, but other implementations may provide other
+   * By default it leaves the headers unformatted, but other implementations may provide other
    * formattings.
    *
    * Note that this does not change the content of the headers in the actual response.

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
@@ -42,26 +42,15 @@ trait ResponseLogFormatter {
    * Maps over all headers in this response and performs formatting (masking, prettyprinting, etc.)
    * for each of them. It returns a new `HeaderMap` with the same keys and the formatted values.
    *
+   * By default it leaves the headers untouched, but other implementations may provide other
+   * formattings.
+   *
    * Note that this does not change the content of the headers in the actual response.
    *
    * @param headers the headers to be formatted
    * @return a mapping of the headers' keys to their formatted values
    */
-  protected def formatResponseHeaders(headers: HeaderMap): HeaderMap = {
-    headers.map(formatResponseHeader)
-  }
-
-  /**
-   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
-   * By default it leaves the header untouched, but other implementations may provide other
-   * formattings.
-   *
-   * Note that this does not change the content of the specific header in the actual response.
-   *
-   * @param header the header to be formatted
-   * @return the formatted header
-   */
-  protected def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = header
+  protected def formatResponseHeaders(headers: HeaderMap): HeaderMap = headers
 
   private def getHeaderMap(response: HttpServletResponse): HeaderMap = {
     response.getHeaderNames.asScala.toSeq
@@ -77,19 +66,5 @@ trait ResponseLogFormatter {
    * @param actionHeaders the actionHeaders to be formatted
    * @return the formatted actionHeaders
    */
-  protected def formatActionHeaders(actionHeaders: ActionHeadersMap): ActionHeadersMap = {
-    actionHeaders.map(formatActionHeader)
-  }
-
-  /**
-   * Formats (masking, prettyprinting, etc.) the given header's value for logging purposes.
-   * By default it leaves the header untouched, but other implementations may provide other
-   * formattings.
-   *
-   * Note that this does not change the content of the specific header in the actual response.
-   *
-   * @param header the header to be formatted
-   * @return the formatted header
-   */
-  protected def formatActionHeader(header: ActionHeaderEntry): ActionHeaderEntry = header
+  protected def formatActionHeaders(actionHeaders: ActionHeadersMap): ActionHeadersMap = actionHeaders
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.lib.logging.servlet
 
-import com.typesafe.scalalogging.{ LazyLogging, Logger }
+import com.typesafe.scalalogging.Logger
 import org.scalatra.{ ActionResult, ScalatraBase }
 
 trait AbstractServletLogger {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -49,7 +49,9 @@ trait AbstractServletLogger {
    *
    *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
    *     get("/") {
-   *       logResponse(Ok("All is well"))
+   *       logResponse {
+   *         Ok("All is well")
+   *       }
    *     }
    *   }
    * }}}

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedAuthenticationParameters.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedAuthenticationParameters.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.request
 
-import nl.knaw.dans.lib.logging.servlet.{ MultiParamsEntry, RequestLogFormatter }
+import nl.knaw.dans.lib.logging.servlet.{ MultiParamsEntry, RequestLogExtensionBase }
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedAuthenticationParameters extends RequestLogFormatter {
+private[masked] trait MaskedAuthenticationParameters extends RequestLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override protected def formatParameter(param: MultiParamsEntry): MultiParamsEntry = {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedAuthorizationHeader.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedAuthorizationHeader.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.request
 
-import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, RequestLogFormatter }
+import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, RequestLogExtensionBase }
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedAuthorizationHeader extends RequestLogFormatter {
+private[masked] trait MaskedAuthorizationHeader extends RequestLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedCookie.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedCookie.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.request
 
-import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, RequestLogFormatter }
+import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, RequestLogExtensionBase }
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedCookie extends RequestLogFormatter {
+private[masked] trait MaskedCookie extends RequestLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedRemoteAddress.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedRemoteAddress.scala
@@ -32,8 +32,8 @@ private[masked] trait MaskedRemoteAddress extends RequestLogExtensionBase {
    *
    * Services without public access might not need to mask.
    */
-  override protected def formatRemoteAddress(remoteAddress: String): String = {
+  abstract override protected def formatRemoteAddress(remoteAddress: String): String = {
     // TODO https://docs.oracle.com/javase/9/docs/api/java/net/Inet6Address.html
-    remoteAddress.replaceAll("([0-9]+[.]){3}", "**.**.**.")
+    super.formatRemoteAddress(remoteAddress).replaceAll("([0-9]+[.]){3}", "**.**.**.")
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedRemoteAddress.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedRemoteAddress.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.request
 
-import nl.knaw.dans.lib.logging.servlet.RequestLogFormatter
+import nl.knaw.dans.lib.logging.servlet.RequestLogExtensionBase
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedRemoteAddress extends RequestLogFormatter {
+private[masked] trait MaskedRemoteAddress extends RequestLogExtensionBase {
   this: ScalatraBase =>
 
   /**

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedRemoteUser.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedRemoteUser.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.response
 
-import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, ResponseLogFormatter }
+import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, ResponseLogExtensionBase }
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedRemoteUser extends ResponseLogFormatter {
+private[masked] trait MaskedRemoteUser extends ResponseLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedSetCookie.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedSetCookie.scala
@@ -15,10 +15,10 @@
  */
 package nl.knaw.dans.lib.logging.servlet.masked.response
 
-import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, ResponseLogFormatter }
+import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, ResponseLogExtensionBase }
 import org.scalatra.ScalatraBase
 
-private[masked] trait MaskedSetCookie extends ResponseLogFormatter {
+private[masked] trait MaskedSetCookie extends ResponseLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -29,8 +29,8 @@ import org.scalatra.ActionResult
  * https://github.com/scalatra/scalatra/blob/6a614d17c38d19826467adcabf1dc746e3192dfc/README.markdown
  * sections #filters #action.
  *
- * Using `org.scalatra.util.RequestLogging` broke other unit test as it added a session header to
- * some responses.
+ * Using `org.scalatra.util.RequestLogging` broke unit test in easy-deposit-api as it added a session
+ * header to some responses.
  *
  * ==Usage==
  * To enable servlet logging, add the `ServletLogger` trait to servlet definition, together with

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -41,7 +41,6 @@ import org.scalatra.ActionResult
  * as well in order mask things like authorization headers, cookies, remote addresses and
  * authentication parameters.
  *
- * @example
  * {{{
  *    import nl.knaw.dans.lib.logging.DebugEnhancedLogging
  *    import nl.knaw.dans.lib.logging.servlet._
@@ -54,6 +53,37 @@ import org.scalatra.ActionResult
  *    }
  *
  *    class MaskedServlet extends ScalatraServlet with ServletLogger with MaskedLogFormatter with DebugEnhancedLogging {
+ *      get("/") {
+ *        Ok("All is well").logResponse
+ *      }
+ *    }
+ * }}}
+ *
+ * ==Extension==
+ * To write custom extensions to the log formatter, create a trait that extends either `RequestLogExtensionBase`
+ * or `ResponseLogExtensionBase`. In this trait, implement the desired method (`formatHeader`, `formatParameter`,
+ * `formatResponseHeader` or `formatActionHeader`), using an `abstract override` (which is important for mixing in
+ * this formatter with the others). Keep in mind that the formatter should only return a formatted version of the
+ * input and not mutate or perform side effects on it.
+ *
+ * {{{
+ *    trait MyCustomRequestHeaderFormatter extends RequestLogExtensionBase {
+ *      this: ScalatraBase =>
+ *
+ *      abstract override protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = {
+ *        super.formatHeader(header) match {
+ *          case (name, values) if name.toLowerCase == "my-header" =>
+ *            name -> values.map(formatMyHeader)
+ *          case otherwise => otherwise
+ *        }
+ *      }
+ *
+ *      private def formatMyHeader(value: String): String = {
+ *        // return some formatting of 'value'
+ *      }
+ *    }
+ *
+ *    class ExampleServlet extends ScalatraServlet with ServletLogger with MyCustomRequestHeaderFormatter with DebugEnhancedLogging {
  *      get("/") {
  *        Ok("All is well").logResponse
  *      }


### PR DESCRIPTION
This PR proposes to move the formatters for the individual headers/parameters to traits that extend `RequestLogFormatter` and `ResponseLogFormatter`. By default, the implementation of the formatters for the list of headers/parameters doesn't do any formatting, neither does it map over each individual element in order to modify nothing.
Only when using the new `RequestLogExtensionBase` and `ResponseLogExtensionBase` do we map over each individual element.

The already existing package on masking now has its individual formatters extend from these new traits.

No tests, nor public APIs require any change by applying this PR.