### PR TITLE
add request url to response log

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
@@ -39,11 +39,12 @@ trait ResponseLogFormatter {
    */
   protected def formatResponseLog(actionResult: ActionResult): String = {
     val method = request.getMethod
+    val requestURL = request.getRequestURL.toString
     val status = actionResult.status
     val formattedAuthHeaders = formatResponseHeaders(getHeaderMap(response)).makeString
     val formattedActionHeaders = formatActionHeaders(actionResult.headers).makeString
 
-    s"$method returned status=$status; authHeaders=$formattedAuthHeaders; actionHeaders=$formattedActionHeaders"
+    s"$method $requestURL returned status=$status; authHeaders=$formattedAuthHeaders; actionHeaders=$formattedActionHeaders"
   }
 
   /**

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
@@ -77,7 +77,7 @@ class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJett
       requestLine should startWith(s"GET http://localhost:$port$path")
       requestLine should include(s"remote=$formattedRemote;")
 
-      responseLine should startWith(s"GET returned status=200; ")
+      responseLine should startWith(s"GET http://localhost:$port$path returned status=200; ")
       responseLine.toLowerCase() should include(s"content-type -> [text/plain;charset=utf-8]")
       responseLine should include(s"actionHeaders=[]")
     }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatterSpec.scala
@@ -34,6 +34,7 @@ class ResponseLogFormatterSpec extends FlatSpec with Matchers with MockFactory w
   override protected def mockRequest: HttpServletRequest = {
     val req = super.mockRequest
     (() => req.getMethod) expects() returning "GET" anyNumberOfTimes()
+    (() => req.getRequestURL) expects() returning new StringBuffer("http://does.not.exist.dans.knaw.nl") anyNumberOfTimes()
     req
   }
 
@@ -50,11 +51,11 @@ class ResponseLogFormatterSpec extends FlatSpec with Matchers with MockFactory w
 
   "formatResponseLog" should "return a formatted log String for the response" in {
     new TestServlet().formatResponseLog(Ok(headers = Map("some" -> "header"))) shouldBe
-      "GET returned status=200; authHeaders=[Set-Cookie -> [scentry.auth.default.user=abc456.pq.xy], REMOTE_USER -> [somebody], Expires -> [Thu, 01 Jan 1970 00:00:00 GMT]]; actionHeaders=[some -> header]"
+      "GET http://does.not.exist.dans.knaw.nl returned status=200; authHeaders=[Set-Cookie -> [scentry.auth.default.user=abc456.pq.xy], REMOTE_USER -> [somebody], Expires -> [Thu, 01 Jan 1970 00:00:00 GMT]]; actionHeaders=[some -> header]"
   }
 
   it should "mask everything when using the MaskedResponseLogFormatter" in {
     (new TestServlet() with MaskedResponseLogFormatter).formatResponseLog(Ok(headers = Map("some" -> "header"))) shouldBe
-      "GET returned status=200; authHeaders=[Set-Cookie -> [scentry.auth.default.user=****.****.****], REMOTE_USER -> [*****], Expires -> [Thu, 01 Jan 1970 00:00:00 GMT]]; actionHeaders=[some -> header]"
+      "GET http://does.not.exist.dans.knaw.nl returned status=200; authHeaders=[Set-Cookie -> [scentry.auth.default.user=****.****.****], REMOTE_USER -> [*****], Expires -> [Thu, 01 Jan 1970 00:00:00 GMT]]; actionHeaders=[some -> header]"
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/ServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/ServletLoggerSpec.scala
@@ -75,10 +75,12 @@ class ServletLoggerSpec extends FlatSpec with Matchers with MockFactory with Emb
   }
 
   it should "call the logResponse on sending a response" in {
+    val port = localPort.fold("None")(_.toString)
+
     (() => mockedLogger.isInfoEnabled()) expects() twice() returning true
     (mockedLogger.info(_: String)) expects where {
       s: String =>
-        (s startsWith s"GET returned status=200") &&
+        (s startsWith s"GET http://localhost:$port$testLoggerPath returned status=200") &&
           (s.toLowerCase contains "content-type -> [text/plain;charset=utf-8]") &&
           (s contains "actionHeaders=[]")
     } once()


### PR DESCRIPTION
I thought it would be good to add the request url to the response log line as well, in order to (hopefully) get somewhat of a better match between log lines.

@jo-pol what do you think?